### PR TITLE
Update README with DarkBERT download instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ A modern Gradio app for masked language modeling, with batch mode, prompt librar
 
 **Requires access to s2w-ai/DarkBERT.**
 
+### Downloading DarkBERT Locally
+
+DarkBERT is a gated model. Request access at <https://huggingface.co/s2w-ai/DarkBERT> and run `huggingface-cli login` once granted.
+Download `config.json`, `pytorch_model.bin`, `tokenizer.json`, `vocab.json`, `merges.txt`, `tokenizer_config.json`, and `special_tokens_map.json` and place them in a new `darkbert_cache/` directory (already listed in `.gitignore`).
+You may also set `cache_dir="darkbert_cache"` when creating the `pipeline` in `app.py`.
+
 ---
 
 Standard prompts can be edited in `app.py` (see the `STANDARD_PROMPTS` list).


### PR DESCRIPTION
## Summary
- document how to download DarkBERT files locally

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt` *(fails: blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_6871dd709e50832c9ac5c012201c8b08